### PR TITLE
fix FixHeresyForEnemies not null checking characterBody

### DIFF
--- a/SimulacrumAdditions/SimulacrumAdditions.csproj
+++ b/SimulacrumAdditions/SimulacrumAdditions.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="MMHOOK.RoR2" Version="2025.6.3" />
     <PackageReference Include="R2API" Version="5.0.5" />
-    <PackageReference Include="R2API.Skins" Version="1.2.0" />
+    <PackageReference Include="R2API.Skins" Version="1.2.1" />
     <PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.9-r.0" />
     <PackageReference Include="Rune580.Mods.RiskOfRain2.RiskOfOptions" Version="2.8.3" />
   </ItemGroup>

--- a/SimulacrumAdditions/code/Waves/Waves_ItemGiving.cs
+++ b/SimulacrumAdditions/code/Waves/Waves_ItemGiving.cs
@@ -233,7 +233,7 @@ namespace SimulacrumAdditions
 
         private static void FixHeresyForEnemies(On.RoR2.GenericSkill.orig_SetSkillOverride orig, GenericSkill self, object source, RoR2.Skills.SkillDef skillDef, GenericSkill.SkillOverridePriority priority)
         {
-            if (priority == GenericSkill.SkillOverridePriority.Replacement && !self.characterBody.isPlayerControlled && self.stateMachine)
+            if (priority == GenericSkill.SkillOverridePriority.Replacement && self.characterBody != null && !self.characterBody.isPlayerControlled && self.stateMachine)
             {
                 //Debug.Log(source);
                 EntityStateMachine stateMachine = self.stateMachine;


### PR DESCRIPTION
so i've helped some with a w.i.p character and they have a separate copy of the skills hud with unique skills. i threw them into my modpack, and found out that the `FixHeresyForEnemies` method from this mod errors out when the copied skills hud loads because `characterBody` is null (ig because the copied skills hud is not entirely attached to the character even though they use it just fine). so i added a null check for characterbody. didn't bump the mod's version in case you wanna save that for including other fixes/additions too.